### PR TITLE
fix: Remove fixed title

### DIFF
--- a/locosopa/src/print_landscape.ytml.yaml
+++ b/locosopa/src/print_landscape.ytml.yaml
@@ -24,7 +24,7 @@ html:
   lang: en
   content:
     head:
-      title: Snakemake - a framework for reproducible data analysis
+      title: ?f"{config["project"]["name"]} - {config["project"]["slogan"]}"
       link:
         rel: stylesheet
         href: print_landscape.css


### PR DESCRIPTION
This PR fixes the title to be set to Snakemake for other projects. I added a slogan key to the project definitions for that.