### PR TITLE
feat: Allow setting image width via img-width

### DIFF
--- a/locosopa/src/index.ytml.yaml
+++ b/locosopa/src/index.ytml.yaml
@@ -161,7 +161,7 @@ html:
                                     ?if item["img-width"]:
                                       style: "width: 200px; max-width: 100vw;"
                                     ?else:
-                                      style: ?f'width: {item["img-width"]}; max-width: 100vw;'
+                                      style: ?f"width: {item['img-width']}; max-width: 100vw;"
                                     content: null
 
                   - div:

--- a/locosopa/src/index.ytml.yaml
+++ b/locosopa/src/index.ytml.yaml
@@ -161,7 +161,7 @@ html:
                                     ?if item["img-width"]:
                                       style: "width: 200px; max-width: 100vw;"
                                     ?else:
-                                      style: ?f"width: {item["img-width"]}; max-width: 100vw;"
+                                      style: ?f'width: {item["img-width"]}; max-width: 100vw;'
                                     content: null
 
                   - div:

--- a/locosopa/src/index.ytml.yaml
+++ b/locosopa/src/index.ytml.yaml
@@ -158,7 +158,10 @@ html:
                                       file: 
                                         path: ?relpath(item["img"])
                                     class: "rounded-lg"
-                                    style: "width: 200px; max-width: 100vw;"
+                                    ?if item["img-width"]:
+                                      style: "width: 200px; max-width: 100vw;"
+                                    ?else
+                                      style: ?f"width: {item["img-width"]}; max-width: 100vw;"
                                     content: null
 
                   - div:

--- a/locosopa/src/index.ytml.yaml
+++ b/locosopa/src/index.ytml.yaml
@@ -161,10 +161,10 @@ html:
                                       file: 
                                         path: ?relpath(item["img"])
                                     class: "rounded-lg"
-                                    ?if item["img-width"]:
-                                      style: "width: 200px; max-width: 100vw;"
-                                    ?else:
+                                    ?if hasattr(item, 'img-width'):
                                       style: ?img_width(item['img-width'])
+                                    ?else:
+                                      style: "width: 200px; max-width: 100vw;"
                                     content: null
 
                   - div:

--- a/locosopa/src/index.ytml.yaml
+++ b/locosopa/src/index.ytml.yaml
@@ -7,6 +7,9 @@ __definitions__:
     def heroicon(name):
       return f"https://raw.githubusercontent.com/tailwindlabs/heroicons/master/src/24/outline/{name}.svg"
   - |
+    def img_width(width):
+      return f"width: {width}; max-width: 100vw;"
+  - |
     def hlt(string):
       def colorize(name, brightness=500):
         return f"<span class='text-{color}-{brightness}'>{name}</span>"
@@ -161,7 +164,7 @@ html:
                                     ?if item["img-width"]:
                                       style: "width: 200px; max-width: 100vw;"
                                     ?else:
-                                      style: ?f"width: {item['img-width']}; max-width: 100vw;"
+                                      style: ?img_width(item['img-width'])
                                     content: null
 
                   - div:

--- a/locosopa/src/index.ytml.yaml
+++ b/locosopa/src/index.ytml.yaml
@@ -160,7 +160,7 @@ html:
                                     class: "rounded-lg"
                                     ?if item["img-width"]:
                                       style: "width: 200px; max-width: 100vw;"
-                                    ?else
+                                    ?else:
                                       style: ?f"width: {item["img-width"]}; max-width: 100vw;"
                                     content: null
 

--- a/locosopa/src/index.ytml.yaml
+++ b/locosopa/src/index.ytml.yaml
@@ -161,7 +161,7 @@ html:
                                       file: 
                                         path: ?relpath(item["img"])
                                     class: "rounded-lg"
-                                    ?if hasattr(item, 'img-width'):
+                                    ?if 'img-width' in item:
                                       style: ?img_width(item['img-width'])
                                     ?else:
                                       style: "width: 200px; max-width: 100vw;"


### PR DESCRIPTION
This PR allows to customize the width of an image in features with `img-width` like so:

```yaml
features:
  - title: Easily configurable interactive reports
    desc: |
      Lorem Ipsum
    img: preview.png
    img-width: 30vw
    url: ...
```