### PR TITLE
fix: added bot config

### DIFF
--- a/locosopa/workflow/scripts/fediwall.py
+++ b/locosopa/workflow/scripts/fediwall.py
@@ -45,6 +45,7 @@ def main():
         "hideBoosts": False,
         "hideReplies": False,
         "hideSensitive": False,
+        "hideBots": False,
     }
 
     # Download fediwall with checksum verification


### PR DESCRIPTION
added a missing bot config option: for the Snakemake fediwall bots should be allowed to be seen. 