### PR TITLE
feat: configured a higher default limit of posts to display

### DIFF
--- a/locosopa/workflow/scripts/fediwall.py
+++ b/locosopa/workflow/scripts/fediwall.py
@@ -42,6 +42,7 @@ def main():
         ],
         "theme": "auto",
         "interval": 30,
+        "limit": 40,
         "hideBoosts": False,
         "hideReplies": False,
         "hideSensitive": False,


### PR DESCRIPTION
The default fediwall limit of posts to display seems to be 20. Which is fine. But for a low frequency posts fediwall like Snakemake, older posts might be interesting.

Also, currently I am the one dominating the fediwall - other people will appear more frequently when the limit is not too low. It might also raise awareness of using the #Snakemake hastag.